### PR TITLE
Add static prototype for Beartell Realtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# beartell_realtime
+# Beartell Realtime
+
+This repository contains a minimal static prototype for the Beartell Realtime
+website. The project provides placeholder pages for various Ultravox REST API
+endpoints and a simple Node server that serves the static files and proxies
+requests to the Ultravox API when network access is available.
+
+## Usage
+
+```
+node server.js
+```
+
+The server listens on port 3000 by default. Navigate to `http://localhost:3000`
+to access the site.
+
+The implementation avoids external dependencies and does not include a working
+Google OAuth flow due to the offline environment.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "beartell_realtime",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/accounts.html
+++ b/public/accounts.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Accounts</title>
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+<nav>
+<a href="/index.html">Home</a>
+<a href="/accounts.html">Accounts</a>
+<a href="/agents.html">Agents</a>
+<a href="/calls.html">Calls</a>
+<a href="/messages.html">Messages</a>
+<a href="/stages.html">Stages</a>
+<a href="/corpora.html">Corpora</a>
+<a href="/query.html">Query</a>
+<a href="/sources.html">Sources</a>
+<a href="/tools.html">Tools</a>
+<a href="/voices.html">Voices</a>
+<a href="/webhooks.html">Webhooks</a>
+<a href="/login.html">Login</a>
+</nav>
+<div class="container">
+<h1>Accounts</h1>
+<p>This page would interface with the Ultravox API for accounts.</p>
+</div>
+</body>
+</html>

--- a/public/agents.html
+++ b/public/agents.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Agents</title>
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+<nav>
+<a href="/index.html">Home</a>
+<a href="/accounts.html">Accounts</a>
+<a href="/agents.html">Agents</a>
+<a href="/calls.html">Calls</a>
+<a href="/messages.html">Messages</a>
+<a href="/stages.html">Stages</a>
+<a href="/corpora.html">Corpora</a>
+<a href="/query.html">Query</a>
+<a href="/sources.html">Sources</a>
+<a href="/tools.html">Tools</a>
+<a href="/voices.html">Voices</a>
+<a href="/webhooks.html">Webhooks</a>
+<a href="/login.html">Login</a>
+</nav>
+<div class="container">
+<h1>Agents</h1>
+<p>This page would interface with the Ultravox API for agents.</p>
+</div>
+</body>
+</html>

--- a/public/calls.html
+++ b/public/calls.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Calls</title>
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+<nav>
+<a href="/index.html">Home</a>
+<a href="/accounts.html">Accounts</a>
+<a href="/agents.html">Agents</a>
+<a href="/calls.html">Calls</a>
+<a href="/messages.html">Messages</a>
+<a href="/stages.html">Stages</a>
+<a href="/corpora.html">Corpora</a>
+<a href="/query.html">Query</a>
+<a href="/sources.html">Sources</a>
+<a href="/tools.html">Tools</a>
+<a href="/voices.html">Voices</a>
+<a href="/webhooks.html">Webhooks</a>
+<a href="/login.html">Login</a>
+</nav>
+<div class="container">
+<h1>Calls</h1>
+<p>This page would interface with the Ultravox API for calls.</p>
+</div>
+</body>
+</html>

--- a/public/corpora.html
+++ b/public/corpora.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Corpora</title>
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+<nav>
+<a href="/index.html">Home</a>
+<a href="/accounts.html">Accounts</a>
+<a href="/agents.html">Agents</a>
+<a href="/calls.html">Calls</a>
+<a href="/messages.html">Messages</a>
+<a href="/stages.html">Stages</a>
+<a href="/corpora.html">Corpora</a>
+<a href="/query.html">Query</a>
+<a href="/sources.html">Sources</a>
+<a href="/tools.html">Tools</a>
+<a href="/voices.html">Voices</a>
+<a href="/webhooks.html">Webhooks</a>
+<a href="/login.html">Login</a>
+</nav>
+<div class="container">
+<h1>Corpora</h1>
+<p>This page would interface with the Ultravox API for corpora.</p>
+</div>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Index</title>
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+<nav>
+<a href="/index.html">Home</a>
+<a href="/accounts.html">Accounts</a>
+<a href="/agents.html">Agents</a>
+<a href="/calls.html">Calls</a>
+<a href="/messages.html">Messages</a>
+<a href="/stages.html">Stages</a>
+<a href="/corpora.html">Corpora</a>
+<a href="/query.html">Query</a>
+<a href="/sources.html">Sources</a>
+<a href="/tools.html">Tools</a>
+<a href="/voices.html">Voices</a>
+<a href="/webhooks.html">Webhooks</a>
+<a href="/login.html">Login</a>
+</nav>
+<div class="container">
+<h1>Index</h1>
+<p>This page would interface with the Ultravox API for index.</p>
+</div>
+</body>
+</html>

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+<nav>
+<a href="/index.html">Home</a>
+<a href="/accounts.html">Accounts</a>
+<a href="/agents.html">Agents</a>
+<a href="/calls.html">Calls</a>
+<a href="/messages.html">Messages</a>
+<a href="/stages.html">Stages</a>
+<a href="/corpora.html">Corpora</a>
+<a href="/query.html">Query</a>
+<a href="/sources.html">Sources</a>
+<a href="/tools.html">Tools</a>
+<a href="/voices.html">Voices</a>
+<a href="/webhooks.html">Webhooks</a>
+<a href="/login.html">Login</a>
+</nav>
+<div class="container">
+<h1>Login</h1>
+<p>Google OAuth integration would be implemented here.</p>
+</div>
+</body>
+</html>

--- a/public/messages.html
+++ b/public/messages.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Messages</title>
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+<nav>
+<a href="/index.html">Home</a>
+<a href="/accounts.html">Accounts</a>
+<a href="/agents.html">Agents</a>
+<a href="/calls.html">Calls</a>
+<a href="/messages.html">Messages</a>
+<a href="/stages.html">Stages</a>
+<a href="/corpora.html">Corpora</a>
+<a href="/query.html">Query</a>
+<a href="/sources.html">Sources</a>
+<a href="/tools.html">Tools</a>
+<a href="/voices.html">Voices</a>
+<a href="/webhooks.html">Webhooks</a>
+<a href="/login.html">Login</a>
+</nav>
+<div class="container">
+<h1>Messages</h1>
+<p>This page would interface with the Ultravox API for messages.</p>
+</div>
+</body>
+</html>

--- a/public/query.html
+++ b/public/query.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Query</title>
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+<nav>
+<a href="/index.html">Home</a>
+<a href="/accounts.html">Accounts</a>
+<a href="/agents.html">Agents</a>
+<a href="/calls.html">Calls</a>
+<a href="/messages.html">Messages</a>
+<a href="/stages.html">Stages</a>
+<a href="/corpora.html">Corpora</a>
+<a href="/query.html">Query</a>
+<a href="/sources.html">Sources</a>
+<a href="/tools.html">Tools</a>
+<a href="/voices.html">Voices</a>
+<a href="/webhooks.html">Webhooks</a>
+<a href="/login.html">Login</a>
+</nav>
+<div class="container">
+<h1>Query</h1>
+<p>This page would interface with the Ultravox API for query.</p>
+</div>
+</body>
+</html>

--- a/public/sources.html
+++ b/public/sources.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Sources</title>
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+<nav>
+<a href="/index.html">Home</a>
+<a href="/accounts.html">Accounts</a>
+<a href="/agents.html">Agents</a>
+<a href="/calls.html">Calls</a>
+<a href="/messages.html">Messages</a>
+<a href="/stages.html">Stages</a>
+<a href="/corpora.html">Corpora</a>
+<a href="/query.html">Query</a>
+<a href="/sources.html">Sources</a>
+<a href="/tools.html">Tools</a>
+<a href="/voices.html">Voices</a>
+<a href="/webhooks.html">Webhooks</a>
+<a href="/login.html">Login</a>
+</nav>
+<div class="container">
+<h1>Sources</h1>
+<p>This page would interface with the Ultravox API for sources.</p>
+</div>
+</body>
+</html>

--- a/public/stages.html
+++ b/public/stages.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Stages</title>
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+<nav>
+<a href="/index.html">Home</a>
+<a href="/accounts.html">Accounts</a>
+<a href="/agents.html">Agents</a>
+<a href="/calls.html">Calls</a>
+<a href="/messages.html">Messages</a>
+<a href="/stages.html">Stages</a>
+<a href="/corpora.html">Corpora</a>
+<a href="/query.html">Query</a>
+<a href="/sources.html">Sources</a>
+<a href="/tools.html">Tools</a>
+<a href="/voices.html">Voices</a>
+<a href="/webhooks.html">Webhooks</a>
+<a href="/login.html">Login</a>
+</nav>
+<div class="container">
+<h1>Stages</h1>
+<p>This page would interface with the Ultravox API for stages.</p>
+</div>
+</body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,21 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background: #f0f0f0;
+}
+nav {
+    background: #333;
+    padding: 10px;
+}
+nav a {
+    color: #fff;
+    margin-right: 10px;
+    text-decoration: none;
+}
+.container {
+    padding: 20px;
+    background: #fff;
+    margin: 20px auto;
+    max-width: 800px;
+}

--- a/public/tools.html
+++ b/public/tools.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Tools</title>
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+<nav>
+<a href="/index.html">Home</a>
+<a href="/accounts.html">Accounts</a>
+<a href="/agents.html">Agents</a>
+<a href="/calls.html">Calls</a>
+<a href="/messages.html">Messages</a>
+<a href="/stages.html">Stages</a>
+<a href="/corpora.html">Corpora</a>
+<a href="/query.html">Query</a>
+<a href="/sources.html">Sources</a>
+<a href="/tools.html">Tools</a>
+<a href="/voices.html">Voices</a>
+<a href="/webhooks.html">Webhooks</a>
+<a href="/login.html">Login</a>
+</nav>
+<div class="container">
+<h1>Tools</h1>
+<p>This page would interface with the Ultravox API for tools.</p>
+</div>
+</body>
+</html>

--- a/public/voices.html
+++ b/public/voices.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Voices</title>
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+<nav>
+<a href="/index.html">Home</a>
+<a href="/accounts.html">Accounts</a>
+<a href="/agents.html">Agents</a>
+<a href="/calls.html">Calls</a>
+<a href="/messages.html">Messages</a>
+<a href="/stages.html">Stages</a>
+<a href="/corpora.html">Corpora</a>
+<a href="/query.html">Query</a>
+<a href="/sources.html">Sources</a>
+<a href="/tools.html">Tools</a>
+<a href="/voices.html">Voices</a>
+<a href="/webhooks.html">Webhooks</a>
+<a href="/login.html">Login</a>
+</nav>
+<div class="container">
+<h1>Voices</h1>
+<p>This page would interface with the Ultravox API for voices.</p>
+</div>
+</body>
+</html>

--- a/public/webhooks.html
+++ b/public/webhooks.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Webhooks</title>
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+<nav>
+<a href="/index.html">Home</a>
+<a href="/accounts.html">Accounts</a>
+<a href="/agents.html">Agents</a>
+<a href="/calls.html">Calls</a>
+<a href="/messages.html">Messages</a>
+<a href="/stages.html">Stages</a>
+<a href="/corpora.html">Corpora</a>
+<a href="/query.html">Query</a>
+<a href="/sources.html">Sources</a>
+<a href="/tools.html">Tools</a>
+<a href="/voices.html">Voices</a>
+<a href="/webhooks.html">Webhooks</a>
+<a href="/login.html">Login</a>
+</nav>
+<div class="container">
+<h1>Webhooks</h1>
+<p>This page would interface with the Ultravox API for webhooks.</p>
+</div>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,60 @@
+const http = require('http');
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+const url = require('url');
+
+const PORT = process.env.PORT || 3000;
+
+const mimeTypes = {
+    '.html': 'text/html',
+    '.css': 'text/css',
+    '.js': 'application/javascript',
+    '.json': 'application/json'
+};
+
+function serveStatic(filePath, res) {
+    fs.readFile(filePath, (err, data) => {
+        if (err) {
+            res.writeHead(404);
+            return res.end('Not found');
+        }
+        const ext = path.extname(filePath);
+        res.writeHead(200, {'Content-Type': mimeTypes[ext] || 'text/plain'});
+        res.end(data);
+    });
+}
+
+function proxyApi(req, res, apiPath) {
+    const options = {
+        hostname: 'api.ultravox.ai',
+        path: apiPath,
+        method: req.method,
+        headers: Object.assign({}, req.headers, {host: 'api.ultravox.ai'})
+    };
+    const proxyReq = https.request(options, proxyRes => {
+        let data = '';
+        proxyRes.on('data', chunk => data += chunk);
+        proxyRes.on('end', () => {
+            res.writeHead(proxyRes.statusCode || 500, proxyRes.headers);
+            res.end(data);
+        });
+    });
+    req.pipe(proxyReq);
+    proxyReq.on('error', err => {
+        res.writeHead(500);
+        res.end(JSON.stringify({error: 'Unable to reach Ultravox API'}));
+    });
+}
+
+const server = http.createServer((req, res) => {
+    const parsed = url.parse(req.url);
+    if (parsed.pathname.startsWith('/api/')) {
+        proxyApi(req, res, parsed.pathname.replace('/api', ''));
+    } else {
+        let filePath = path.join(__dirname, 'public', parsed.pathname === '/' ? 'index.html' : parsed.pathname);
+        serveStatic(filePath, res);
+    }
+});
+
+server.listen(PORT, () => console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- add public pages for Accounts, Agents, Calls, Messages, Stages, Corpora, Query, Sources, Tools, Voices, Webhooks and Login
- include a simple style and index page
- create minimal Node server that serves static files and proxies `/api` calls to the Ultravox API
- document usage in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688372cc8e388329ab810adf592858fb